### PR TITLE
:construction_worker: Ignore Exit Code of npm run lint

### DIFF
--- a/_templates/Jenkinsfile
+++ b/_templates/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
     }
     stage('lint') {
       steps {
-        sh 'npm run lint'
+        sh 'npm run lint || true'
       }
     }
     stage('build') {


### PR DESCRIPTION
## What did you change?

With this change, `npm run lint` is run, but its output code dosent cause jenkins to skip next build steps.

## How can others test the changes?

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
