### PR TITLE
Feature/minstall 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
   "license": "ISC",
   "devDependencies": {
     "meta-npm": "0.0.18",
-    "minstall": "3.0.0-pre1"
+    "minstall": "3.0.0-pre3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
   "license": "ISC",
   "devDependencies": {
     "meta-npm": "0.0.18",
-    "minstall": "^2.0.1"
+    "minstall": "3.0.0-pre1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
   "license": "ISC",
   "devDependencies": {
     "meta-npm": "0.0.18",
-    "minstall": "3.0.0-pre3"
+    "minstall": "3.0.0-pre4"
   }
 }

--- a/setup.sh
+++ b/setup.sh
@@ -4,7 +4,6 @@ npm install -g meta gulp
 # checkout all repos in the correct branch
 meta git update
 meta exec "git checkout develop" --exclude process_engine_meta
-meta exec "git checkout feature/minstall_3" --include-only skeleton
 
 # install all necessary dependencies
 npm install

--- a/setup.sh
+++ b/setup.sh
@@ -4,46 +4,16 @@ npm install -g meta gulp
 # checkout all repos in the correct branch
 meta git update
 meta exec "git checkout develop" --exclude process_engine_meta
+meta exec "git checkout feature/minstall_3" --include-only skeleton
 
 # install all necessary dependencies
 npm install
-
-# install the process-engine-server-demo, and make it use the linked packages
-cd skeleton/process-engine-server-demo
-npm install
-rm -rf node_modules/@process-engine
-rm -rf node_modules/@essential-projects
-cd ../..
-
-# install the process-engine-server, and make it use the linked packages
-cd skeleton/process-engine-server
-npm install
-rm -rf node_modules/@process-engine
-rm -rf node_modules/@essential-projects
-cd ../..
-
-# install the process-engine-server, and make it use the linked packages
-cd skeleton/process-engine-browser
-npm install
-rm -rf node_modules/@process-engine
-rm -rf node_modules/@essential-projects
-cd ../..
 
 # fix conflicting types from jasmine and mocha
 rm -rf node_modules/@types/jasmine
 
 # build all packages and schemas
-meta exec "npm run build-schemas && npm run build" --exclude process_engine_meta,skeleton,documentation,charon
-cd skeleton/process-engine-server-demo
-npm run build
-cd ../process-engine-browser
-npm run build
-cd ../..
-
-# build charon. for some aurelia-reason, this doesn't work with a higher-level node_modules folder
-cd charon
-npm run build
-cd ..
+meta exec "npm run build-schemas && npm run build" --exclude process_engine_meta,documentation
 
 # create a database
 cd skeleton/database

--- a/setup.sh
+++ b/setup.sh
@@ -41,15 +41,7 @@ npm run build
 cd ../..
 
 # build charon. for some aurelia-reason, this doesn't work with a higher-level node_modules folder
-mkdir charon/node_modules
-mkdir charon/node_modules/@essential-projects
-mkdir charon/node_modules/@process-engine
-ln -s ../../../core_contracts charon/node_modules/@essential-projects/core_contracts
-ln -s ../../../event_aggregator charon/node_modules/@essential-projects/event_aggregator
-ln -s ../../../consumer_client charon/node_modules/@process-engine/consumer_client
-ln -s ../../../process_engine_contracts charon/node_modules/@process-engine/process_engine_contracts
 cd charon
-npm install
 npm run build
 cd ..
 

--- a/setup.sh
+++ b/setup.sh
@@ -13,7 +13,8 @@ npm install
 rm -rf node_modules/@types/jasmine
 
 # build all packages and schemas
-meta exec "npm run build-schemas && npm run build" --exclude process_engine_meta,documentation
+meta exec "npm run build-schemas && npm run build" --exclude process_engine_meta,skeleton,documentation,charon
+meta exec "npm run build" --include-only skeleton,charon
 
 # create a database
 cd skeleton/database


### PR DESCRIPTION
## What did you change?

I Updated the minstall-dependency to 3.0.0, which allowes for a much simplified setup and support for npm 5

**DO NOT MERGE UNTIL https://github.com/process-engine/skeleton/pull/24 IS MERGED AND https://github.com/process-engine/process_engine_meta/issues/20 IS FIXED**

The charon-installation does not work correctly with this setup, because the dependency-list of the aurelia-cli-package is broken, see [this issue](https://github.com/aurelia/cli/issues/801). If that is fixed and the aurelia-cli-dependency updated, this should work again

## How can others test the changes?

You can now do the regular dev-setup, even with npm5!

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [ ] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
