### PR TITLE
🐛 add missing token-adapter-config

### DIFF
--- a/_integration_tests/application/config/development/iam/jwt_token_adapter.json
+++ b/_integration_tests/application/config/development/iam/jwt_token_adapter.json
@@ -1,0 +1,3 @@
+{
+  "secret": "notSoSecret"
+}


### PR DESCRIPTION
## What did you change?

The current iam-module requires the consuming application to provide a jwt_token_adapter-config.
This branch adds said config, which makes the tests work again

## How can others test the changes?

- run the regular dev-setup
- switch to the `_integration_tests`-folder
- run `npm test`
- see how that doesn't work without this fix

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
