### PR TITLE
👷 :construction_worker: Only publish on new commits

### DIFF
--- a/_templates/Jenkinsfile
+++ b/_templates/Jenkinsfile
@@ -52,12 +52,12 @@ pipeline {
       }
     }
     stage('publish') {
+      // Check if the build is trigged by a new git commit;
+      // if this is a new commit, publish to NPM.
       when {
         allOf {
           branch 'master'
           expression {
-            // check if the build is trigged
-            // by a new git commit
             env.GIT_PREVIOUS_COMMIT != env.GIT_COMMIT
           }
         }

--- a/_templates/Jenkinsfile
+++ b/_templates/Jenkinsfile
@@ -53,7 +53,14 @@ pipeline {
     }
     stage('publish') {
       when {
-        branch 'master'
+        allOf {
+          branch 'master'
+          expression {
+            // check if the build is trigged
+            // by a new git commit
+            env.GIT_PREVIOUS_COMMIT != env.GIT_COMMIT
+          }
+        }
       }
       steps {
         nodejs(configId: 'process-engine-ci-token', nodeJSInstallationName: 'node-lts') {


### PR DESCRIPTION
## What did you change?

Before: Any build on master would try to publish to npm.org

Now: Only when a new commit is made we publish to npm.org

## How can others test the changes?

n/a

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
