### PR TITLE
⬆️ make minstall not hoist aurelia-packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,12 +4,12 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "postinstall": "minstall ."
+    "postinstall": "minstall --no-hoist aurelia-* ."
   },
   "author": "",
   "license": "ISC",
   "devDependencies": {
     "meta-npm": "0.0.18",
-    "minstall": "^3.0.3"
+    "minstall": "^3.3.0"
   }
 }


### PR DESCRIPTION
## What did you change?

I updated minstall to 3.3.0 and told it to not hoist aurelia-packages. This fixes #20 

## How can others test the changes?

running the setup should now leave you with a working bpmn-studio folder

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
