### PR TITLE
Fixed missing keys for start events in the integration tests.

### DIFF
--- a/_integration_tests/bpmn/boundary_event_message_test.bpmn
+++ b/_integration_tests/bpmn/boundary_event_message_test.bpmn
@@ -6,7 +6,7 @@
   <bpmn:process id="boundary_event_message_test" isExecutable="true">
     <bpmn:laneSet>
       <bpmn:lane id="Lane_1uilmrj" name="Lane">
-        <bpmn:flowNodeRef>StartEvent_1rmaugb</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>StartEvent_1</bpmn:flowNodeRef>
         <bpmn:flowNodeRef>Task1</bpmn:flowNodeRef>
         <bpmn:flowNodeRef>TimerEvent1</bpmn:flowNodeRef>
         <bpmn:flowNodeRef>ParallelSplit1</bpmn:flowNodeRef>
@@ -22,10 +22,10 @@
         <bpmn:flowNodeRef>Task3</bpmn:flowNodeRef>
       </bpmn:lane>
     </bpmn:laneSet>
-    <bpmn:startEvent id="StartEvent_1rmaugb" name="Start">
+    <bpmn:startEvent id="StartEvent_1" name="Start">
       <bpmn:outgoing>SequenceFlow_1xmddm8</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:sequenceFlow id="SequenceFlow_1xmddm8" sourceRef="StartEvent_1rmaugb" targetRef="Task1" />
+    <bpmn:sequenceFlow id="SequenceFlow_1xmddm8" sourceRef="StartEvent_1" targetRef="Task1" />
     <bpmn:scriptTask id="Task1" name="Set the current token value to 1">
       <bpmn:incoming>SequenceFlow_1xmddm8</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1dxqlsb</bpmn:outgoing>
@@ -119,7 +119,7 @@
       <bpmndi:BPMNShape id="Participant_1yuoono_di" bpmnElement="Participant_1yuoono">
         <dc:Bounds x="236" y="211" width="1337" height="449.61400000000003" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="StartEvent_1rmaugb_di" bpmnElement="StartEvent_1rmaugb">
+      <bpmndi:BPMNShape id="StartEvent_1rmaugb_di" bpmnElement="StartEvent_1">
         <dc:Bounds x="342" y="329.61400000000003" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="348" y="369" width="24" height="13" />

--- a/_integration_tests/bpmn/boundary_event_signal_test.bpmn
+++ b/_integration_tests/bpmn/boundary_event_signal_test.bpmn
@@ -6,7 +6,7 @@
   <bpmn:process id="boundary_event_signal_test" isExecutable="true">
     <bpmn:laneSet>
       <bpmn:lane id="Lane_1uilmrj" name="Lane">
-        <bpmn:flowNodeRef>StartEvent_1rmaugb</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>StartEvent_1</bpmn:flowNodeRef>
         <bpmn:flowNodeRef>Task1</bpmn:flowNodeRef>
         <bpmn:flowNodeRef>TimerEvent1</bpmn:flowNodeRef>
         <bpmn:flowNodeRef>ParallelSplit1</bpmn:flowNodeRef>
@@ -22,10 +22,10 @@
         <bpmn:flowNodeRef>SignalBoundaryEvent1</bpmn:flowNodeRef>
       </bpmn:lane>
     </bpmn:laneSet>
-    <bpmn:startEvent id="StartEvent_1rmaugb" name="Start">
+    <bpmn:startEvent id="StartEvent_1" name="Start">
       <bpmn:outgoing>SequenceFlow_1xmddm8</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:sequenceFlow id="SequenceFlow_1xmddm8" sourceRef="StartEvent_1rmaugb" targetRef="Task1" />
+    <bpmn:sequenceFlow id="SequenceFlow_1xmddm8" sourceRef="StartEvent_1" targetRef="Task1" />
     <bpmn:scriptTask id="Task1" name="Set the current token value to 1">
       <bpmn:incoming>SequenceFlow_1xmddm8</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1dxqlsb</bpmn:outgoing>
@@ -120,7 +120,7 @@
       <bpmndi:BPMNShape id="Participant_1yuoono_di" bpmnElement="Participant_1yuoono">
         <dc:Bounds x="236" y="211" width="1337" height="449.61400000000003" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="StartEvent_1rmaugb_di" bpmnElement="StartEvent_1rmaugb">
+      <bpmndi:BPMNShape id="StartEvent_1rmaugb_di" bpmnElement="StartEvent_1">
         <dc:Bounds x="342" y="329.61400000000003" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="348" y="369" width="24" height="13" />

--- a/_integration_tests/bpmn/boundary_event_timer_test.bpmn
+++ b/_integration_tests/bpmn/boundary_event_timer_test.bpmn
@@ -20,7 +20,7 @@
           <camunda:executionListener class="" event="" />
           <camunda:properties />
         </bpmn:extensionElements>
-        <bpmn:flowNodeRef>StartEvent_01</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>StartEvent_1</bpmn:flowNodeRef>
         <bpmn:flowNodeRef>Task2</bpmn:flowNodeRef>
         <bpmn:flowNodeRef>Task1</bpmn:flowNodeRef>
         <bpmn:flowNodeRef>Task3</bpmn:flowNodeRef>
@@ -34,7 +34,7 @@
         <bpmn:flowNodeRef>EndEvent_0nvdzre</bpmn:flowNodeRef>
       </bpmn:lane>
     </bpmn:laneSet>
-    <bpmn:startEvent id="StartEvent_01" name="Start">
+    <bpmn:startEvent id="StartEvent_1" name="Start">
       <bpmn:extensionElements>
         <camunda:executionListener class="" event="" />
         <camunda:properties />
@@ -66,7 +66,7 @@
       </bpmn:timerEventDefinition>
     </bpmn:boundaryEvent>
     <bpmn:sequenceFlow id="SequenceFlow_14jiq0l" sourceRef="Task2" targetRef="XORJoin1" />
-    <bpmn:sequenceFlow id="SequenceFlow_05i47eo" sourceRef="StartEvent_01" targetRef="Task1" />
+    <bpmn:sequenceFlow id="SequenceFlow_05i47eo" sourceRef="StartEvent_1" targetRef="Task1" />
     <bpmn:scriptTask id="Task1" name="Set the current token value to 1">
       <bpmn:incoming>SequenceFlow_05i47eo</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_155dsxu</bpmn:outgoing>
@@ -140,7 +140,7 @@
           <dc:Bounds x="1662" y="250" width="20" height="13" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="StartEvent_16du69e_di" bpmnElement="StartEvent_01">
+      <bpmndi:BPMNShape id="StartEvent_16du69e_di" bpmnElement="StartEvent_1">
         <dc:Bounds x="170" y="211.07" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="176" y="250" width="24" height="13" />

--- a/_integration_tests/test/boundary_event_tests.js
+++ b/_integration_tests/test/boundary_event_tests.js
@@ -21,6 +21,7 @@ describe('Boundary Event', () => {
     const expectedToken = {
       current: 2,
       history: {
+        StartEvent_1: {},
         Task1: 1,
         ParallelSplit1: 1,
         TimerEvent1: 1,
@@ -45,6 +46,7 @@ describe('Boundary Event', () => {
     const expectedToken = {
       current: 2,
       history: {
+        StartEvent_1: {},
         Task1: 1,
         ParallelSplit1: 1,
         TimerEvent1: 1,

--- a/_integration_tests/test/catch_throw_event_test.js
+++ b/_integration_tests/test/catch_throw_event_test.js
@@ -23,6 +23,7 @@ describe('Intermediate Catch Throw events test', () => {
     const expectedToken = {
       current: 2,
       history: {
+        StartEvent_1: {},
         Task1: 1,
         ParallelSplit1: 1,
         TimerEvent1: 1,
@@ -46,6 +47,7 @@ describe('Intermediate Catch Throw events test', () => {
     const expectedToken = {
       current: 2,
       history: {
+        StartEvent_1: {},
         Task1: 1,
         ParallelSplit1: 1,
         TimerEvent1: 1,

--- a/_integration_tests/test/timer_boundary_event_test.js
+++ b/_integration_tests/test/timer_boundary_event_test.js
@@ -23,6 +23,7 @@ describe('Timer Boundary Event Tests', () => {
     const expectedToken = {
       current: 3,
       history: {
+        StartEvent_1: {},
         Task1: 1,
         TimerBoudary1: 1,
         Task2: 2,


### PR DESCRIPTION
## What did you change?
In some tests, the start event was missing in the expected token object definition, which could cause them to fail. 

I added the missing start event entries to the expected token object to match the correct token history.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
