### PR TITLE
Move bpmn file loading from the ioc module to the test scripts

### DIFF
--- a/_integration_tests/ioc_module.js
+++ b/_integration_tests/ioc_module.js
@@ -13,20 +13,7 @@ const registerInContainer = (container) => {
 
   // add processes for use with the integrationtests here
   const processes = [
-    'boundary_event_message_test',
-    'boundary_event_signal_test',
-    'boundary_event_error_test',
-    'boundary_event_timer_test',
-    'intermediate_event_message_test',
-    'intermediate_event_signal_test',
     'generic_sample',
-    'parallel_gateway_test',
-    'script_task_test',
-    'service_task_test',
-    'subprocess_test',
-    'terminate_end_event_sample',
-    'xor_gateway_base_test',
-    'xor_gateway_nested',
   ];
 
   processes.map((processFilename) => {

--- a/_integration_tests/src/test_fixture_provider.ts
+++ b/_integration_tests/src/test_fixture_provider.ts
@@ -103,7 +103,7 @@ export class TestFixtureProvider {
    * Generate an absoulte file path, which points to the bpmn process definition files.
    * @param directoryName Name of the directory, which contains the bpmn files
    */
-  private generateFilePath(directoryName: string): string {
+  private resolvePath(directoryName: string): string {
 
     // TODO: Maybe refacor.
     // This works, but is not really nice. There are currently some edge cases, where this method
@@ -126,20 +126,18 @@ export class TestFixtureProvider {
    * @param directoryName If set, load the bpmn process definition file from this directory. If unset, use
    * bpmn/  as a default directory.
    */
-  public async loadProcessesFromBPMNFiles(filelist: Array<string>, directoryName: string): Promise<void> {
+  public async loadProcessesFromBPMNFiles(filelist: Array<string>, directoryName: string = 'bpmn'): Promise<void> {
     // Load the Process Definition Entity Type Service once to prevent an ioc container lookup on every iteration.
     const processDefEntityTypeService: any = await this.container.resolveAsync('ProcessDefEntityTypeService');
-
-    const bpmnDefFileDirectoryName: string = directoryName || 'bpmn';
 
     // Check, if the current working directory is the directory specified in integrationTestDirName.
     // If not, append the name to the rootDirPath.
     // This is necessary, because jenkins fails to start the tests, since the cwd on jenkins
     // is different then on the local machine while running the tests.
-    const bpmnFilePath: string = this.generateFilePath(bpmnDefFileDirectoryName);
+    const bpmnDirPath: string = this.resolvePath(directoryName);
 
     for (const file of filelist) {
-      const filePath: string = path.join(bpmnFilePath, file);
+      const filePath: string = path.join(bpmnDirPath, file);
       await this.getProcessFromFile(filePath, processDefEntityTypeService);
     }
   }

--- a/_integration_tests/src/test_fixture_provider.ts
+++ b/_integration_tests/src/test_fixture_provider.ts
@@ -100,18 +100,10 @@ export class TestFixtureProvider {
   }
 
   /**
-   * Load all given processes with their matching process definition files.
-   * @param directoryName Name of the directory which contains the bpmn files that should be loaded.
-   * @param filelist List of the process definition bpmn files. The filename must end with .bmpn.
+   * Generate an absoulte file path, which points to the bpmn process definition files.
+   * @param directoryName Name of the directory, which contains the bpmn files
    */
-  public async loadProcessesFromBPMNFiles(directoryName: string, filelist: Array<string>): Promise<void> {
-    // Load the Process Definition Entity Type Service once to prevent an ioc container lookup on every iteration.
-    const processDefEntityTypeService: any = await this.container.resolveAsync('ProcessDefEntityTypeService');
-
-    // Check, if the current working directory is the directory specified in integrationTestDirName.
-    // If not, append the name to the rootDirPath.
-    // This is necessary, because jenkins fails to start the tests, since the cwd on jenkins
-    // is different then on the local machine while running the tests.
+  private generateFilePath(directoryName: string): string {
 
     // TODO: Maybe refacor.
     // This works, but is not really nice. There are currently some edge cases, where this method
@@ -125,8 +117,29 @@ export class TestFixtureProvider {
       rootDirPath = path.join(rootDirPath, integrationTestDirName);
     }
 
+    return path.join(rootDirPath, directoryName);
+  }
+
+  /**
+   * Load all given processes with their matching process definition files.
+   * @param filelist List of the process definition bpmn files. The filename must end with .bmpn.
+   * @param directoryName If set, load the bpmn process definition file from this directory. If unset, use
+   * bpmn/  as a default directory.
+   */
+  public async loadProcessesFromBPMNFiles(filelist: Array<string>, directoryName: string): Promise<void> {
+    // Load the Process Definition Entity Type Service once to prevent an ioc container lookup on every iteration.
+    const processDefEntityTypeService: any = await this.container.resolveAsync('ProcessDefEntityTypeService');
+
+    const bpmnDefFileDirectoryName: string = directoryName || 'bpmn';
+
+    // Check, if the current working directory is the directory specified in integrationTestDirName.
+    // If not, append the name to the rootDirPath.
+    // This is necessary, because jenkins fails to start the tests, since the cwd on jenkins
+    // is different then on the local machine while running the tests.
+    const bpmnFilePath: string = this.generateFilePath(bpmnDefFileDirectoryName);
+
     for (const file of filelist) {
-      const filePath: string = path.join(rootDirPath, directoryName, file);
+      const filePath: string = path.join(bpmnFilePath, file);
       await this.getProcessFromFile(filePath, processDefEntityTypeService);
     }
   }

--- a/_integration_tests/src/test_fixture_provider.ts
+++ b/_integration_tests/src/test_fixture_provider.ts
@@ -105,6 +105,11 @@ export class TestFixtureProvider {
    */
   private resolvePath(directoryName: string): string {
 
+    // Check, if the current working directory is the directory specified in integrationTestDirName (see below).
+    // If not, append the name to the rootDirPath.
+    // This is necessary, because jenkins fails to start the tests, since the cwd on jenkins
+    // is different then on the local machine while running the tests.
+
     // TODO: Maybe refacor.
     // This works, but is not really nice. There are currently some edge cases, where this method
     // method should fail. For Example when there are two nested integration test directories. In a directory
@@ -129,11 +134,6 @@ export class TestFixtureProvider {
   public async loadProcessesFromBPMNFiles(filelist: Array<string>, directoryName: string = 'bpmn'): Promise<void> {
     // Load the Process Definition Entity Type Service once to prevent an ioc container lookup on every iteration.
     const processDefEntityTypeService: any = await this.container.resolveAsync('ProcessDefEntityTypeService');
-
-    // Check, if the current working directory is the directory specified in integrationTestDirName.
-    // If not, append the name to the rootDirPath.
-    // This is necessary, because jenkins fails to start the tests, since the cwd on jenkins
-    // is different then on the local machine while running the tests.
     const bpmnDirPath: string = this.resolvePath(directoryName);
 
     for (const file of filelist) {

--- a/_integration_tests/test/boundary_event_tests.js
+++ b/_integration_tests/test/boundary_event_tests.js
@@ -10,12 +10,12 @@ describe('Boundary Event - ', () => {
     testFixtureProvider = new TestFixtureProvider();
     await testFixtureProvider.initializeAndStart();
 
-    const bpmnProcessDefDirectory = 'bpmn';
     const processDefList = [
       'boundary_event_message_test.bpmn',
-      'boundary_event_signal_test.bpmn'];
+      'boundary_event_signal_test.bpmn',
+    ];
 
-    await testFixtureProvider.loadProcessesFromBPMNFiles(bpmnProcessDefDirectory, processDefList);
+    await testFixtureProvider.loadProcessesFromBPMNFiles(processDefList);
   });
 
   after(async () => {

--- a/_integration_tests/test/boundary_event_tests.js
+++ b/_integration_tests/test/boundary_event_tests.js
@@ -9,6 +9,13 @@ describe('Boundary Event - ', () => {
   before(async () => {
     testFixtureProvider = new TestFixtureProvider();
     await testFixtureProvider.initializeAndStart();
+
+    const bpmnProcessDefDirectory = 'bpmn';
+    const processDefList = [
+      'boundary_event_message_test.bpmn',
+      'boundary_event_signal_test.bpmn'];
+
+    await testFixtureProvider.loadProcessesFromBPMNFiles(bpmnProcessDefDirectory, processDefList);
   });
 
   after(async () => {

--- a/_integration_tests/test/call_activity_tests.js
+++ b/_integration_tests/test/call_activity_tests.js
@@ -12,15 +12,15 @@ describe('Call activity tests', () => {
     testFixtureProvider = new TestFixtureProvider();
     await testFixtureProvider.initializeAndStart();
 
-    const bpmnProcessDefDirectory = 'bpmn';
     const processDefFileList = ['call_activity_base_test.bpmn',
       'call_activity_nested_process.bpmn',
       'call_activity_normal_process.bpmn',
       'call_activity_throw_exception.bpmn',
-      'call_activity_throw_exception_test.bpmn'];
+      'call_activity_throw_exception_test.bpmn',
+    ];
 
     // Load all processes definitions that belongs to the test
-    await testFixtureProvider.loadProcessesFromBPMNFiles(bpmnProcessDefDirectory, processDefFileList);
+    await testFixtureProvider.loadProcessesFromBPMNFiles(processDefFileList);
 
   });
 

--- a/_integration_tests/test/call_activity_tests.js
+++ b/_integration_tests/test/call_activity_tests.js
@@ -13,7 +13,6 @@ describe('Call activity tests', () => {
     await testFixtureProvider.initializeAndStart();
 
     const bpmnProcessDefDirectory = 'bpmn';
-
     const processDefFileList = ['call_activity_base_test.bpmn',
       'call_activity_nested_process.bpmn',
       'call_activity_normal_process.bpmn',

--- a/_integration_tests/test/error_boundary_event_test.js
+++ b/_integration_tests/test/error_boundary_event_test.js
@@ -12,6 +12,12 @@ describe('Error Boundary Event - ', () => {
   before(async () => {
     testFixtureProvider = new TestFixtureProvider();
     await testFixtureProvider.initializeAndStart();
+
+    const bpmnProcessDefDirectory = 'bpmn';
+    const processDefFileList = ['boundary_event_error_test.bpmn'];
+
+    await testFixtureProvider.loadProcessesFromBPMNFiles(bpmnProcessDefDirectory, processDefFileList);
+
   });
 
   after(async () => {

--- a/_integration_tests/test/error_boundary_event_test.js
+++ b/_integration_tests/test/error_boundary_event_test.js
@@ -13,10 +13,9 @@ describe('Error Boundary Event - ', () => {
     testFixtureProvider = new TestFixtureProvider();
     await testFixtureProvider.initializeAndStart();
 
-    const bpmnProcessDefDirectory = 'bpmn';
     const processDefFileList = ['boundary_event_error_test.bpmn'];
 
-    await testFixtureProvider.loadProcessesFromBPMNFiles(bpmnProcessDefDirectory, processDefFileList);
+    await testFixtureProvider.loadProcessesFromBPMNFiles(processDefFileList);
 
   });
 

--- a/_integration_tests/test/intermediate_event_tests.js
+++ b/_integration_tests/test/intermediate_event_tests.js
@@ -10,6 +10,13 @@ describe('Intermediate Events - ', () => {
   before(async () => {
     testFixtureProvider = new TestFixtureProvider();
     await testFixtureProvider.initializeAndStart();
+
+    const bpmnProcessDefDirectory = 'bpmn';
+    const processDefFileList = [
+      'intermediate_event_message_test.bpmn',
+      'intermediate_event_signal_test.bpmn'];
+
+    await testFixtureProvider.loadProcessesFromBPMNFiles(bpmnProcessDefDirectory, processDefFileList);
   });
 
   after(async () => {

--- a/_integration_tests/test/intermediate_event_tests.js
+++ b/_integration_tests/test/intermediate_event_tests.js
@@ -11,12 +11,12 @@ describe('Intermediate Events - ', () => {
     testFixtureProvider = new TestFixtureProvider();
     await testFixtureProvider.initializeAndStart();
 
-    const bpmnProcessDefDirectory = 'bpmn';
     const processDefFileList = [
       'intermediate_event_message_test.bpmn',
-      'intermediate_event_signal_test.bpmn'];
+      'intermediate_event_signal_test.bpmn',
+    ];
 
-    await testFixtureProvider.loadProcessesFromBPMNFiles(bpmnProcessDefDirectory, processDefFileList);
+    await testFixtureProvider.loadProcessesFromBPMNFiles(processDefFileList);
   });
 
   after(async () => {

--- a/_integration_tests/test/parallel_gateway_test.js
+++ b/_integration_tests/test/parallel_gateway_test.js
@@ -10,6 +10,12 @@ describe('Parallel Gateway execution', () => {
   before(async () => {
     testFixtureProvider = new TestFixtureProvider();
     await testFixtureProvider.initializeAndStart();
+
+    const bpmnProcessDefDirectory = 'bpmn';
+    const processDefFileList = ['parallel_gateway_test.bpmn'];
+
+    await testFixtureProvider.loadProcessesFromBPMNFiles(bpmnProcessDefDirectory, processDefFileList);
+
   });
 
   after(async () => {

--- a/_integration_tests/test/parallel_gateway_test.js
+++ b/_integration_tests/test/parallel_gateway_test.js
@@ -11,10 +11,9 @@ describe('Parallel Gateway execution', () => {
     testFixtureProvider = new TestFixtureProvider();
     await testFixtureProvider.initializeAndStart();
 
-    const bpmnProcessDefDirectory = 'bpmn';
     const processDefFileList = ['parallel_gateway_test.bpmn'];
 
-    await testFixtureProvider.loadProcessesFromBPMNFiles(bpmnProcessDefDirectory, processDefFileList);
+    await testFixtureProvider.loadProcessesFromBPMNFiles(processDefFileList);
 
   });
 

--- a/_integration_tests/test/script_task_tests.js
+++ b/_integration_tests/test/script_task_tests.js
@@ -11,6 +11,12 @@ describe('Script Tasks - ', () => {
   before(async () => {
     testFixtureProvider = new TestFixtureProvider();
     await testFixtureProvider.initializeAndStart();
+
+    const bpmnProcessDefDirectory = 'bpmn';
+    const processDefFiles = ['script_task_test.bpmn'];
+
+    await testFixtureProvider.loadProcessesFromBPMNFiles(bpmnProcessDefDirectory, processDefFiles);
+
   });
 
   after(async () => {

--- a/_integration_tests/test/script_task_tests.js
+++ b/_integration_tests/test/script_task_tests.js
@@ -12,10 +12,8 @@ describe('Script Tasks - ', () => {
     testFixtureProvider = new TestFixtureProvider();
     await testFixtureProvider.initializeAndStart();
 
-    const bpmnProcessDefDirectory = 'bpmn';
     const processDefFiles = ['script_task_test.bpmn'];
-
-    await testFixtureProvider.loadProcessesFromBPMNFiles(bpmnProcessDefDirectory, processDefFiles);
+    await testFixtureProvider.loadProcessesFromBPMNFiles(processDefFiles);
 
   });
 

--- a/_integration_tests/test/service_task_tests.js
+++ b/_integration_tests/test/service_task_tests.js
@@ -11,6 +11,11 @@ describe('Service Task - ', () => {
   before(async () => {
     testFixtureProvider = new TestFixtureProvider();
     await testFixtureProvider.initializeAndStart();
+
+    const bpmnProcessDefDirector = 'bpmn';
+    const processDefFileList = ['service_task_test.bpmn'];
+
+    await testFixtureProvider.loadProcessesFromBPMNFiles(bpmnProcessDefDirector, processDefFileList);
   });
 
   after(async () => {

--- a/_integration_tests/test/service_task_tests.js
+++ b/_integration_tests/test/service_task_tests.js
@@ -12,10 +12,8 @@ describe('Service Task - ', () => {
     testFixtureProvider = new TestFixtureProvider();
     await testFixtureProvider.initializeAndStart();
 
-    const bpmnProcessDefDirector = 'bpmn';
     const processDefFileList = ['service_task_test.bpmn'];
-
-    await testFixtureProvider.loadProcessesFromBPMNFiles(bpmnProcessDefDirector, processDefFileList);
+    await testFixtureProvider.loadProcessesFromBPMNFiles(processDefFileList);
   });
 
   after(async () => {

--- a/_integration_tests/test/subprocess.js
+++ b/_integration_tests/test/subprocess.js
@@ -15,10 +15,8 @@ describe('SubProcess', () => {
     testFixtureProvider = new TestFixtureProvider();
     await testFixtureProvider.initializeAndStart();
 
-    const bpmnProcessDefDirectory = 'bpmn';
     const processDefFileList = ['subprocess_test.bpmn'];
-
-    await testFixtureProvider.loadProcessesFromBPMNFiles(bpmnProcessDefDirectory, processDefFileList);
+    await testFixtureProvider.loadProcessesFromBPMNFiles(processDefFileList);
   });
 
   after(async () => {

--- a/_integration_tests/test/subprocess.js
+++ b/_integration_tests/test/subprocess.js
@@ -14,6 +14,11 @@ describe('SubProcess', () => {
   before(async () => {
     testFixtureProvider = new TestFixtureProvider();
     await testFixtureProvider.initializeAndStart();
+
+    const bpmnProcessDefDirectory = 'bpmn';
+    const processDefFileList = ['subprocess_test.bpmn'];
+
+    await testFixtureProvider.loadProcessesFromBPMNFiles(bpmnProcessDefDirectory, processDefFileList);
   });
 
   after(async () => {

--- a/_integration_tests/test/terminate_end_event.js
+++ b/_integration_tests/test/terminate_end_event.js
@@ -16,10 +16,9 @@ describe('Terminate End Event', () => {
     testFixtureProvider = new TestFixtureProvider();
     await testFixtureProvider.initializeAndStart();
 
-    const bpmnProcessDefDirectory = 'bpmn';
     const processDefFileList = ['terminate_end_event_sample.bpmn'];
 
-    await testFixtureProvider.loadProcessesFromBPMNFiles(bpmnProcessDefDirectory, processDefFileList);
+    await testFixtureProvider.loadProcessesFromBPMNFiles(processDefFileList);
 
     nodeInstanceEntityTypeService = await testFixtureProvider.resolveAsync('NodeInstanceEntityTypeService');
   });

--- a/_integration_tests/test/terminate_end_event.js
+++ b/_integration_tests/test/terminate_end_event.js
@@ -16,6 +16,11 @@ describe('Terminate End Event', () => {
     testFixtureProvider = new TestFixtureProvider();
     await testFixtureProvider.initializeAndStart();
 
+    const bpmnProcessDefDirectory = 'bpmn';
+    const processDefFileList = ['terminate_end_event_sample.bpmn'];
+
+    await testFixtureProvider.loadProcessesFromBPMNFiles(bpmnProcessDefDirectory, processDefFileList);
+
     nodeInstanceEntityTypeService = await testFixtureProvider.resolveAsync('NodeInstanceEntityTypeService');
   });
 

--- a/_integration_tests/test/timer_boundary_event_test.js
+++ b/_integration_tests/test/timer_boundary_event_test.js
@@ -17,10 +17,8 @@ describe('Timer Boundary Event - ', () => {
     testFixtureProvider = new TestFixtureProvider();
     await testFixtureProvider.initializeAndStart();
 
-    const bpmnProcessDefDirectory = 'bpmn';
     const processDefFileList = ['boundary_event_timer_test.bpmn'];
-
-    await testFixtureProvider.loadProcessesFromBPMNFiles(bpmnProcessDefDirectory, processDefFileList);
+    await testFixtureProvider.loadProcessesFromBPMNFiles(processDefFileList);
 
   });
 

--- a/_integration_tests/test/timer_boundary_event_test.js
+++ b/_integration_tests/test/timer_boundary_event_test.js
@@ -16,6 +16,12 @@ describe('Timer Boundary Event - ', () => {
   before(async () => {
     testFixtureProvider = new TestFixtureProvider();
     await testFixtureProvider.initializeAndStart();
+
+    const bpmnProcessDefDirectory = 'bpmn';
+    const processDefFileList = ['boundary_event_timer_test.bpmn'];
+
+    await testFixtureProvider.loadProcessesFromBPMNFiles(bpmnProcessDefDirectory, processDefFileList);
+
   });
 
   after(async () => {

--- a/_integration_tests/test/xor_gateway_tests.js
+++ b/_integration_tests/test/xor_gateway_tests.js
@@ -10,12 +10,11 @@ describe('Exclusive Gateway - ', async () => {
     testFixtureProvider = new TestFixtureProvider();
     await testFixtureProvider.initializeAndStart();
 
-    const bpmnProcessDefDirectory = 'bpmn';
     const processDefFileList = [
       'xor_gateway_base_test.bpmn',
       'xor_gateway_nested.bpmn'];
 
-    await testFixtureProvider.loadProcessesFromBPMNFiles(bpmnProcessDefDirectory, processDefFileList);
+    await testFixtureProvider.loadProcessesFromBPMNFiles(processDefFileList);
   });
 
   after(async () => {

--- a/_integration_tests/test/xor_gateway_tests.js
+++ b/_integration_tests/test/xor_gateway_tests.js
@@ -12,7 +12,8 @@ describe('Exclusive Gateway - ', async () => {
 
     const processDefFileList = [
       'xor_gateway_base_test.bpmn',
-      'xor_gateway_nested.bpmn'];
+      'xor_gateway_nested.bpmn',
+    ];
 
     await testFixtureProvider.loadProcessesFromBPMNFiles(processDefFileList);
   });

--- a/_integration_tests/test/xor_gateway_tests.js
+++ b/_integration_tests/test/xor_gateway_tests.js
@@ -9,6 +9,13 @@ describe('Exclusive Gateway - ', async () => {
   before(async () => {
     testFixtureProvider = new TestFixtureProvider();
     await testFixtureProvider.initializeAndStart();
+
+    const bpmnProcessDefDirectory = 'bpmn';
+    const processDefFileList = [
+      'xor_gateway_base_test.bpmn',
+      'xor_gateway_nested.bpmn'];
+
+    await testFixtureProvider.loadProcessesFromBPMNFiles(bpmnProcessDefDirectory, processDefFileList);
   });
 
   after(async () => {


### PR DESCRIPTION
## What did you change?
Ive moved the loading of the process definition file from the ioc module to the test script.

A reason why this was necessary is, that on one hand, the ioc module gets pretty messy. On the other hand, a test script should be complete by it selfs. It should not be necessary for a user who writes a test script to register a reference to his process definition file in another generic Javascript module. 

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
