### PR TITLE
Adjust timer boundary test durations

### DIFF
--- a/_integration_tests/bpmn/boundary_event_timer_test.bpmn
+++ b/_integration_tests/bpmn/boundary_event_timer_test.bpmn
@@ -59,12 +59,12 @@
       <bpmn:outgoing>SequenceFlow_1x79rp3</bpmn:outgoing>
       <bpmn:script>return JSON.parse(JSON.stringify(token));</bpmn:script>
     </bpmn:scriptTask>
-    <bpmn:serviceTask id="ITask2" name="Run 15 seconds">
+    <bpmn:serviceTask id="ITask2" name="Run 6 seconds">
       <bpmn:extensionElements>
         <camunda:properties>
           <camunda:property name="module" value="ServiceTaskTestService" />
           <camunda:property name="method" value="delay" />
-          <camunda:property name="params" value="[15, token.current]" />
+          <camunda:property name="params" value="[6, token.current]" />
         </camunda:properties>
       </bpmn:extensionElements>
       <bpmn:incoming>SequenceFlow_0htcapw</bpmn:incoming>
@@ -80,12 +80,12 @@
       <bpmn:outgoing>SequenceFlow_04hoc8f</bpmn:outgoing>
       <bpmn:script>return token.current + 1</bpmn:script>
     </bpmn:scriptTask>
-    <bpmn:serviceTask id="NITask2" name="Run 15 seconds">
+    <bpmn:serviceTask id="NITask2" name="Run 2 seconds">
       <bpmn:extensionElements>
         <camunda:properties>
           <camunda:property name="module" value="ServiceTaskTestService" />
           <camunda:property name="method" value="delay" />
-          <camunda:property name="params" value="[15, token.current]" />
+          <camunda:property name="params" value="[2, token.current]" />
         </camunda:properties>
       </bpmn:extensionElements>
       <bpmn:incoming>SequenceFlow_0759mm3</bpmn:incoming>
@@ -101,10 +101,10 @@
       <bpmn:outgoing>SequenceFlow_12kce5b</bpmn:outgoing>
       <bpmn:script>return token.current + 1;</bpmn:script>
     </bpmn:scriptTask>
-    <bpmn:boundaryEvent id="TimerBoundary2" name="Break after 20 seconds" attachedToRef="NITask2">
+    <bpmn:boundaryEvent id="TimerBoundary2" name="Break after 6 seconds" attachedToRef="NITask2">
       <bpmn:outgoing>SequenceFlow_082fvqw</bpmn:outgoing>
       <bpmn:timerEventDefinition>
-        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P0Y0M0DT0H0M20S</bpmn:timeDuration>
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P0Y0M0DT0H0M6S</bpmn:timeDuration>
       </bpmn:timerEventDefinition>
     </bpmn:boundaryEvent>
     <bpmn:boundaryEvent id="ITimerBoundary1" name="Break after 2 seconds" attachedToRef="ITask2">
@@ -201,7 +201,7 @@
       <bpmndi:BPMNShape id="BoundaryEvent_0s0q33f_di" bpmnElement="TimerBoundary2">
         <dc:Bounds x="600" y="537" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="638" y="543" width="70" height="25" />
+          <dc:Bounds x="642" y="543" width="63" height="24" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_1ons7lm_di" bpmnElement="IXORJoin1" isMarkerVisible="true">

--- a/_integration_tests/test/boundary_event_timer_test.js
+++ b/_integration_tests/test/boundary_event_timer_test.js
@@ -7,9 +7,6 @@ describe('Timer Boundary Event - ', () => {
 
   let testFixtureProvider;
 
-  // Raise the timout for this test to 30 seconds.
-  const testTimeout = 20000;
-
   // Every Test uses the same process model.
   const processKey = 'boundary_event_timer_test';
 
@@ -53,7 +50,7 @@ describe('Timer Boundary Event - ', () => {
     const result = await testFixtureProvider.executeProcess(processKey, initialToken);
 
     should(result).be.eql(expectedToken);
-  }).timeout(testTimeout);
+  });
 
   it('should not interrupt a service task that finishes, before the timespan of the timer boundary event is over', async () => {
 
@@ -81,5 +78,5 @@ describe('Timer Boundary Event - ', () => {
 
     should(result).be.eql(expectedToken);
 
-  }).timeout(testTimeout);
+  });
 });


### PR DESCRIPTION
## What did you change?
This PR adjusts the test durations which are used in the timer boundary event tests. This should enhance the jenkins run time since the tests only delays 6 instead of 15 seconds in the worst, and 2 instead of 15 seconds in the normal case. 

## How can others test the changes?
run `npm test`

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
