### PR TITLE
[WIP]Execute the ExclusiveGateway Integration Test before all others

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -111,7 +111,7 @@ pipeline {
           def db_link = "--link ${db_container_id}:db";
 
           server_image.inside("${node_env} ${junit_report_path} ${config_path} ${db_host} ${db_link}") {
-            error_code = sh(script: "node /usr/src/app/node_modules/.bin/mocha --timeout 60000 /usr/src/app/test/*.js /urs/src/app/test/exclusive_gateway_test.js $(find /urs/src/app/test -name '*.js' -and -not -name 'exclusive_gateway_test.js' -exec echo -n {} +) --colors --reporter mocha-jenkins-reporter --exit > result.txt", returnStatus: true);
+            error_code = sh(script: "node /usr/src/app/node_modules/.bin/mocha --timeout 60000 /usr/src/app/test/*.js /urs/src/app/test/exclusive_gateway_test.js \$(find /urs/src/app/test -name '*.js' -and -not -name 'exclusive_gateway_test.js' -exec echo -n {} +) --colors --reporter mocha-jenkins-reporter --exit > result.txt", returnStatus: true);
             testresults = sh(script: "cat result.txt", returnStdout: true).trim();
 
             junit 'report.xml'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -111,7 +111,7 @@ pipeline {
           def db_link = "--link ${db_container_id}:db";
 
           server_image.inside("${node_env} ${junit_report_path} ${config_path} ${db_host} ${db_link}") {
-            error_code = sh(script: "node /usr/src/app/node_modules/.bin/mocha --timeout 60000 /usr/src/app/test/*.js --colors --reporter mocha-jenkins-reporter --exit > result.txt", returnStatus: true);
+            error_code = sh(script: "node /usr/src/app/node_modules/.bin/mocha --timeout 60000 /usr/src/app/test/*.js /urs/src/app/test/exclusive_gateway_test.js $(find /urs/src/app/test -name '*.js' -and -not -name 'exclusive_gateway_test.js' -exec echo -n {} +) --colors --reporter mocha-jenkins-reporter --exit > result.txt", returnStatus: true);
             testresults = sh(script: "cat result.txt", returnStdout: true).trim();
 
             junit 'report.xml'

--- a/_integration_tests/package.json
+++ b/_integration_tests/package.json
@@ -12,7 +12,7 @@
   ],
   "scripts": {
     "start": "cross-env NODE_ENV=test CONFIG_PATH=config node index.js",
-    "test": "cross-env NODE_ENV=test CONFIG_PATH=config mocha -t 15000 test/exclusive_gateway_test.js $(find test -type f -and -name '*.js' -and -not -name 'exclusive_gateway_test.js' -exec echo -n {} +)  --exit",
+    "test": "cross-env NODE_ENV=test CONFIG_PATH=config mocha -t 15000 test/exclusive_gateway_test.js $(find test -name '*.js' -and -not -name 'exclusive_gateway_test.js' -exec echo -n {} +)  --exit",
     "test-debug": "cross-env NODE_ENV=test CONFIG_PATH=config mocha --inspect-brk test/*.js --exit",
     "build": "gulp build"
   },

--- a/_integration_tests/package.json
+++ b/_integration_tests/package.json
@@ -12,7 +12,7 @@
   ],
   "scripts": {
     "start": "cross-env NODE_ENV=test CONFIG_PATH=config node index.js",
-    "test": "cross-env NODE_ENV=test CONFIG_PATH=config mocha -t 15000 test/*.js --exit",
+    "test": "cross-env NODE_ENV=test CONFIG_PATH=config mocha -t 15000 test/exclusive_gateway_test.js $(find test -type f -and -name '*.js' -and -not -name 'exclusive_gateway_test.js' -exec echo -n {} +)  --exit",
     "test-debug": "cross-env NODE_ENV=test CONFIG_PATH=config mocha --inspect-brk test/*.js --exit",
     "build": "gulp build"
   },


### PR DESCRIPTION
## What did you change?
This PR lets the integration Test for the Exclusive Gateway before all others. Since many tests rely on the exclusive gateway, I thought its a good Idea to run the xor gateway tests before all other tests. 

_Maybe it would also be good, if the test execution stops, if the xor gateway tests fails._

To achieve this, its necessary to pass the desired test order as command line arguments to the `mocha` command. 

```
mocha test1.js test2.js...
``` 

This is done via the find command, which selects every test file that is not the exclusive gateway test from the test folder. Therefore, we can pass the exclusive gateway test script as a first and then all other test scripts as following command line arguments. 

## How can others test the changes?
* Run `npm test` in the `_integration_tests` directory
* Look at the test execution order

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [ ] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
