### PR TITLE
Enable tests for the ErrorEndEvent

### DIFF
--- a/_integration_tests/ioc_module.js
+++ b/_integration_tests/ioc_module.js
@@ -13,6 +13,7 @@ const registerInContainer = (container) => {
 
   // add processes for use with the integrationtests here
   const processes = [
+    'boundary_event_conditional',
     'boundary_event_error_test',
     'boundary_event_message_test',
     'boundary_event_signal_test',
@@ -22,7 +23,8 @@ const registerInContainer = (container) => {
     'call_activity_subprocess_nested',
     'call_activity_test',
     'call_activity_test_error',
-    'boundary_event_conditional',
+    'error_end_event_test',
+    'error_end_event_subprocess_call_activity_test',
     'exclusive_gateway_base_test',
     'exclusive_gateway_nested',
     'generic_sample',

--- a/_integration_tests/test/error_end_event_test.js
+++ b/_integration_tests/test/error_end_event_test.js
@@ -2,7 +2,7 @@
 const should = require('should');
 const TestFixtureProver = require('../dist/commonjs/test_fixture_provider').TestFixtureProvider;
 
-describe.skip('Error End Event - ', () => {
+describe('Error End Event - ', () => {
 
   let testFixtureProvider;
 
@@ -39,7 +39,7 @@ describe.skip('Error End Event - ', () => {
     should(processInstancePromise).be.rejectedWith(expectedErrorObject);
   });
 
-  it('should execute a call activity which ends with an error boundary event', async () => {
+  it.skip('should execute a call activity which ends with an error boundary event', async () => {
     const processModelKey = 'error_end_event_subprocess_call_activity_test';
 
     const initialToken = {
@@ -62,7 +62,7 @@ describe.skip('Error End Event - ', () => {
       'XORJoin'];
 
     should(result).have.property('history');
-    should(result.history).have.keys(expectedHistoryKeys);
+    should(result.history).have.keys(...expectedHistoryKeys);
   });
 
   it('should execute a subprocess which ends with an error end event', async () => {
@@ -88,6 +88,6 @@ describe.skip('Error End Event - ', () => {
     ];
 
     should(result).have.property('history');
-    should(result.history).have.keys(expectedHistoryKeys);
+    should(result.history).have.keys(...expectedHistoryKeys);
   });
 });


### PR DESCRIPTION
## What did you change?
This PR enables the defines integration tests for the ErrorEndEvent.

## Notice
This PR should only be merged, if https://github.com/process-engine/process_engine/pull/102 is merge, since the mentioned PR adds the ErrorEndEvent handlers to the process engine.

This PR also relies on the merge for the user task handler, since the current state on develop points to the `user task handler` feature branch of the process engine.

## How can others test the changes?
Run `npm test` in the `_integration_tests` directory.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [ ] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [ ] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [ ] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
