### PR TITLE
Use a TryCatch block instead of should.be.rejectedWith()

### DIFF
--- a/_integration_tests/test/error_end_event_test.js
+++ b/_integration_tests/test/error_end_event_test.js
@@ -24,8 +24,6 @@ describe.skip('Error End Event - ', () => {
   it('should throw an error, when the error end event is reached', async () => {
     const processModelKey = 'error_end_event_test';
 
-    const processInstancePromise = testFixtureProvider.executeProcess(processModelKey);
-
     /*
      * TODO: Since the behavior of the ErrorEndEvent is not fully designed,
      * the object that is returned from a process that ends with an
@@ -36,7 +34,11 @@ describe.skip('Error End Event - ', () => {
       name: 'Expected Error',
     };
 
-    should(processInstancePromise).be.rejectedWith(expectedErrorObject);
+    try {
+      await testFixtureProvider.executeProcess(processModelKey);
+    } catch (error) {
+      should(error).be.eql(expectedErrorObject);
+    }
   });
 
   it('should execute a call activity which ends with an error boundary event', async () => {

--- a/_integration_tests/test/script_task_tests.js
+++ b/_integration_tests/test/script_task_tests.js
@@ -49,7 +49,7 @@ describe('Script Tasks - ', () => {
     try {
       await testFixtureProvider.executeProcess(processModelKey, initialToken)
     } catch (error) {
-      should(error)
+      should(error.message)
         .match(expectedMessage);
     }
   });

--- a/_integration_tests/test/script_task_tests.js
+++ b/_integration_tests/test/script_task_tests.js
@@ -46,7 +46,11 @@ describe('Script Tasks - ', () => {
 
     const expectedMessage = /a.*?not.*?defined/i;
 
-    await testFixtureProvider.executeProcess(processModelKey, initialToken)
-      .should.be.rejectedWith(expectedMessage);
+    try {
+      await testFixtureProvider.executeProcess(processModelKey, initialToken)
+    } catch (error) {
+      should(error)
+        .match(expectedMessage);
+    }
   });
 });

--- a/_integration_tests/test/script_task_tests.js
+++ b/_integration_tests/test/script_task_tests.js
@@ -49,8 +49,7 @@ describe('Script Tasks - ', () => {
     try {
       await testFixtureProvider.executeProcess(processModelKey, initialToken)
     } catch (error) {
-      should(error.message)
-        .match(expectedMessage);
+      should(error.message).be.match(expectedMessage);
     }
   });
 });

--- a/_integration_tests/test/service_task_tests.js
+++ b/_integration_tests/test/service_task_tests.js
@@ -68,8 +68,7 @@ describe('Service Task - ', () => {
     try {
       await testFixtureProvider.executeProcess(processKey, initialToken);
     } catch (error) {
-      should(error.message)
-        .match(expectedErrorMessage);
+      should(error.message).be.match(expectedErrorMessage);
     }
   });
 });

--- a/_integration_tests/test/service_task_tests.js
+++ b/_integration_tests/test/service_task_tests.js
@@ -62,14 +62,14 @@ describe('Service Task - ', () => {
     };
 
     // Expected exception content
-    const expectedExceptionContent = /Failed/i;
+    const expectedErrorMessage = /Failed/i;
 
     // Check, if the exception is thrown and the promise is rejected.
     try {
       await testFixtureProvider.executeProcess(processKey, initialToken);
     } catch (error) {
-      should(error)
-        .match(expectedExceptionContent);
+      should(error.message)
+        .match(expectedErrorMessage);
     }
   });
 });

--- a/_integration_tests/test/service_task_tests.js
+++ b/_integration_tests/test/service_task_tests.js
@@ -65,6 +65,11 @@ describe('Service Task - ', () => {
     const expectedExceptionContent = /Failed/i;
 
     // Check, if the exception is thrown and the promise is rejected.
-    await testFixtureProvider.executeProcess(processKey, initialToken).should.be.rejectedWith(expectedExceptionContent);
+    try {
+      await testFixtureProvider.executeProcess(processKey, initialToken);
+    } catch (error) {
+      should(error)
+        .match(expectedExceptionContent);
+    }
   });
 });

--- a/_integration_tests/test/terminate_end_event.js
+++ b/_integration_tests/test/terminate_end_event.js
@@ -43,8 +43,7 @@ describe('Terminate End Event', () => {
 
       // NOTE: This only shows the Blackbox Result of the test. To verify that the process- and all corresponding nodes
       // were actually terminated, we need to query the database.
-      should(error.message)
-        .match(expectedError);
+      should(error.message).be.match(expectedError);
       await assertActiveNodeInstancesWereTerminated(processInstanceId);
       await assertPendingNodesWereNotCreated(processInstanceId);
     }

--- a/_integration_tests/test/user_task_tests.js
+++ b/_integration_tests/test/user_task_tests.js
@@ -144,7 +144,9 @@ describe('User Tasks - ', () => {
       },
     };
 
-    const expectedMessage = /.*UserTask*.User_Task_2.*not.*found/i;
+    const errorName = /.*not.*found/i;
+    const errorMessage = /.*User_Task_2.*/i;
+    const errorCode = 404;
 
     try {
       // Try to finish the user task which is currently not waiting
@@ -152,8 +154,15 @@ describe('User Tasks - ', () => {
         .consumerApiService
         .finishUserTask(consumerContext, processModelKey, correlationId, 'User_Task_2', userTaskInput);
     } catch (error) {
-      should(error)
-        .match(expectedMessage);
+      should(error).has.properties('name', 'code', 'message');
+
+      should(error.name)
+        .match(errorName);
+
+      should(error.code).be.equal(errorCode);
+
+      should(error.message)
+        .match(errorMessage);
     }
   });
 
@@ -175,7 +184,9 @@ describe('User Tasks - ', () => {
       },
     };
 
-    const expectedMessage = /.*User_Task_1.*not.*found.*/i;
+    const errorName = /.*not.*found/i;
+    const errorMessage = /.*User_Task_1.*/i;
+    const errorCode = 404;
 
     await testFixtureProvider
       .consumerApiService
@@ -186,8 +197,15 @@ describe('User Tasks - ', () => {
         .consumerApiService
         .finishUserTask(consumerContext, processModelKey, correlationId, 'User_Task_1', userTaskInput);
     } catch (error) {
-      should(error)
-        .match(expectedMessage);
+      should(error).has.properties('code', 'name', 'message');
+
+      should(error.name)
+        .match(errorName);
+
+      should(error.code).be.equal(errorCode);
+
+      should(error.message)
+        .match(errorMessage);
     }
   });
 

--- a/_integration_tests/test/user_task_tests.js
+++ b/_integration_tests/test/user_task_tests.js
@@ -146,12 +146,15 @@ describe('User Tasks - ', () => {
 
     const expectedMessage = /.*UserTask*.User_Task_2.*not.*found/i;
 
-    // Try to finish the user task which is currently not waiting
-    const finishUserTaskPromise = testFixtureProvider
-      .consumerApiService
-      .finishUserTask(consumerContext, processModelKey, correlationId, 'User_Task_2', userTaskInput);
-
-    should(finishUserTaskPromise).be.rejectedWith(expectedMessage);
+    try {
+      // Try to finish the user task which is currently not waiting
+      await testFixtureProvider
+        .consumerApiService
+        .finishUserTask(consumerContext, processModelKey, correlationId, 'User_Task_2', userTaskInput);
+    } catch (error) {
+      should(error)
+        .match(expectedMessage);
+    }
   });
 
   it('should refuse to execute a user task twice', async () => {
@@ -178,11 +181,14 @@ describe('User Tasks - ', () => {
       .consumerApiService
       .finishUserTask(consumerContext, processModelKey, correlationId, 'User_Task_1', userTaskInput);
 
-    const finishUserTaskPromise = testFixtureProvider
-      .consumerApiService
-      .finishUserTask(consumerContext, processModelKey, correlationId, 'User_Task_1', userTaskInput);
-
-    should(finishUserTaskPromise).be.rejectedWith(expectedMessage);
+    try {
+      await testFixtureProvider
+        .consumerApiService
+        .finishUserTask(consumerContext, processModelKey, correlationId, 'User_Task_1', userTaskInput);
+    } catch (error) {
+      should(error)
+        .match(expectedMessage);
+    }
   });
 
   /**

--- a/_integration_tests/test/user_task_tests.js
+++ b/_integration_tests/test/user_task_tests.js
@@ -4,7 +4,6 @@ const should = require('should');
 const TestFixtureProvider = require('../dist/commonjs/test_fixture_provider').TestFixtureProvider;
 const startCallbackType = require('@process-engine/consumer_api_contracts').StartCallbackType;
 
-/* eslint-disable  newline-per-chained-call*/
 describe('User Tasks - ', () => {
   let testFixtureProvider;
   let consumerContext;
@@ -163,9 +162,9 @@ describe('User Tasks - ', () => {
     } catch (error) {
       should(error).have.properties(...errorObjectProperties);
 
-      should(error.name).match(errorName);
+      should(error.name).be.match(errorName);
       should(error.code).be.equal(errorCode);
-      should(error.message).match(errorMessage);
+      should(error.message).be.match(errorMessage);
     }
   });
 
@@ -208,9 +207,9 @@ describe('User Tasks - ', () => {
     } catch (error) {
       should(error).have.properties(...errorObjectProperties);
 
-      should(error.name).match(errorName);
+      should(error.name).be.match(errorName);
       should(error.code).be.equal(errorCode);
-      should(error.message).match(errorMessage);
+      should(error.message).be.match(errorMessage);
     }
   });
 

--- a/_integration_tests/test/user_task_tests.js
+++ b/_integration_tests/test/user_task_tests.js
@@ -4,6 +4,7 @@ const should = require('should');
 const TestFixtureProvider = require('../dist/commonjs/test_fixture_provider').TestFixtureProvider;
 const startCallbackType = require('@process-engine/consumer_api_contracts').StartCallbackType;
 
+/* eslint-disable  newline-per-chained-call*/
 describe('User Tasks - ', () => {
   let testFixtureProvider;
   let consumerContext;
@@ -160,15 +161,11 @@ describe('User Tasks - ', () => {
         .consumerApiService
         .finishUserTask(consumerContext, processModelKey, correlationId, 'User_Task_2', userTaskInput);
     } catch (error) {
-      should(error).has.properties(...errorObjectProperties);
+      should(error).have.properties(...errorObjectProperties);
 
-      should(error.name)
-        .match(errorName);
-
+      should(error.name).match(errorName);
       should(error.code).be.equal(errorCode);
-
-      should(error.message)
-        .match(errorMessage);
+      should(error.message).match(errorMessage);
     }
   });
 
@@ -209,15 +206,11 @@ describe('User Tasks - ', () => {
         .consumerApiService
         .finishUserTask(consumerContext, processModelKey, correlationId, 'User_Task_1', userTaskInput);
     } catch (error) {
-      should(error).has.properties(...errorObjectProperties);
+      should(error).have.properties(...errorObjectProperties);
 
-      should(error.name)
-        .match(errorName);
-
+      should(error.name).match(errorName);
       should(error.code).be.equal(errorCode);
-
-      should(error.message)
-        .match(errorMessage);
+      should(error.message).match(errorMessage);
     }
   });
 

--- a/_integration_tests/test/user_task_tests.js
+++ b/_integration_tests/test/user_task_tests.js
@@ -144,6 +144,12 @@ describe('User Tasks - ', () => {
       },
     };
 
+    const errorObjectProperties = [
+      'name',
+      'code',
+      'message',
+    ];
+
     const errorName = /.*not.*found/i;
     const errorMessage = /.*User_Task_2.*/i;
     const errorCode = 404;
@@ -154,7 +160,7 @@ describe('User Tasks - ', () => {
         .consumerApiService
         .finishUserTask(consumerContext, processModelKey, correlationId, 'User_Task_2', userTaskInput);
     } catch (error) {
-      should(error).has.properties('name', 'code', 'message');
+      should(error).has.properties(...errorObjectProperties);
 
       should(error.name)
         .match(errorName);
@@ -184,6 +190,12 @@ describe('User Tasks - ', () => {
       },
     };
 
+    const errorObjectProperties = [
+      'name',
+      'code',
+      'message',
+    ];
+
     const errorName = /.*not.*found/i;
     const errorMessage = /.*User_Task_1.*/i;
     const errorCode = 404;
@@ -197,7 +209,7 @@ describe('User Tasks - ', () => {
         .consumerApiService
         .finishUserTask(consumerContext, processModelKey, correlationId, 'User_Task_1', userTaskInput);
     } catch (error) {
-      should(error).has.properties('code', 'name', 'message');
+      should(error).has.properties(...errorObjectProperties);
 
       should(error.name)
         .match(errorName);


### PR DESCRIPTION
## What did you change?
It seems, that the function `rejectedWith()` from shouldjs produces false positives. 

For example, if a promise is rejected with a different `message` than defined in 
```
should(promise).be.rejectedWith(expectedMessage);
```
mochja indicates this test als _positive_. 

This PR changes every call to `rejectedWith(message)` to a try catch construct, where this issue doesn't seems to appear.

## How can others test the changes?
run `npm test` 

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
