### PR TITLE
[WIP] 🚧 Make expression tests cover more cases

### DIFF
--- a/_integration_tests/bpmn/user_task_expression_test.bpmn
+++ b/_integration_tests/bpmn/user_task_expression_test.bpmn
@@ -37,7 +37,7 @@
     <bpmn:userTask id="ut_userTask" name="User Task 1">
       <bpmn:extensionElements>
         <camunda:formData>
-          <camunda:formField id="Sample_Form_Field" label="${token.history.st_ProvideResults.one}" type="string" defaultValue="${token.history.st_ProvideResults.two}" />
+          <camunda:formField id="Sample_Form_Field" label="${token.history.st_ProvideResults.one} plus ${token.history.st_ProvideResults.two}" type="string" defaultValue="equals ${token.history.st_ProvideResults.one + token.history.st_ProvideResults.two}." />
         </camunda:formData>
       </bpmn:extensionElements>
       <bpmn:incoming>SequenceFlow_176zufh</bpmn:incoming>

--- a/_integration_tests/test/user_task_tests.js
+++ b/_integration_tests/test/user_task_tests.js
@@ -45,8 +45,8 @@ describe('User Tasks - ', () => {
 
     should(waitingUserTasks.userTasks.length).be.equal(expectedNumberOfWaitingUserTasks);
 
-    const expectedLabelValue = 1;
-    const expectedDefaultValue = 2;
+    const expectedLabelValue = '1 plus 2';
+    const expectedDefaultValue = 'equals 3.';
 
     const waitingUserTaskFieldLabel = waitingUserTasks.userTasks[0].data.formFields[0].label;
     const waitingUserTaskFieldDefaultValue = waitingUserTasks.userTasks[0].data.formFields[0].defaultValue;


### PR DESCRIPTION
🚧 This depends on a PR which is not even open yet. The extended test fails at this point.

**Changes:**

Makes tests more strict:
1.  Cover multiple expressions in a field
1. Cover userinput before, after and inbetween expressions


**Issues:**

Related https://github.com/process-engine/consumer_api_core/issues/52 

PR: #PullRequest

---

## How can others test the changes?

- `npm i`
- `npm run build`
- `npm test`

Tests will fail, because issue is not resolved.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).

## Example

<details>
<summary>
:warning: Before merging please click here to expand and follow the guide.
</summary>
<br>

Please use `:twisted_rightwards_arrows:` at the beginning of your merge commit title.

Example 1:

<pre>
<code>
:twisted_rightwards_arrows: :bug: Fix Wrong Text Decoration at ...
</code>
</pre>

To get your commit message, just copy the first part of this pull request.

Example 2:
<pre>
<code>
**Changes:**

- Fixes Wrong Text Decoration at ...
- Fixes some typos
- ...

**Issues:**

Closes #NumberOfFixedIssue

PR: #NumberOfThisPR
</code>
</pre>
</details>

## Emojis

<details>
<summary>
Expand for a list of most used Emojis.
</summary>
<br>

Please prefix your commit messages with an Emoji.

Ref: https://gitmoji.carloscuesta.me/

| Description              | Glyphe               | Emoji  |
|--------------------------|----------------------|--------|
| Bugfix                   | `:bug:`              | 🐛     |
| Configuration releated   | `:wrench:`           | 🔧     |
| Cosmetic                 | `:lipstick:`         | 💄     |
| Dependencies Downgrade   | `:arrow_down:`       | ⬇️     |
| Dependencies Upgrade     | `:arrow_up:`         | ⬆️     |
| Formatting               | `:art:`              | 🎨     |
| Improving Performance    | `:zap:`              | ⚡️     |
| Initial commit           | `:tada:`             | 🎉     |
| Linter                   | `:rotating_light:`   | 🚨     |
| Miscellaneous            | `:package:`          | 📦     |
| New Feature              | `:sparkles:`         | ✨     |
| Refactoring Code         | `:recycle:`          | ♻️     |
| Releasing / Version tags | `:bookmark:`         | 🔖     |
| Removing Stuff           | `:fire:`             | 🔥     |
| Tests                    | `:white_check_mark:` | ✅     |
| Work In Progress (WIP)   | `:construction:`     | 🚧     |

</details>
