### PR TITLE
✅ Add a test for the Timer Definition validation

### DIFF
--- a/_integration_tests/bpmn/modell_parser_cyclic_timer_test.bpmn
+++ b/_integration_tests/bpmn/modell_parser_cyclic_timer_test.bpmn
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definition_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="BPMN Studio" exporterVersion="1">
+  <bpmn:collaboration id="Collaboration_1cidyxu" name="">
+    <bpmn:participant id="Participant_0px403d" name="modell_parser_cyclic_timer_test" processRef="modell_parser_cyclic_timer_test" />
+  </bpmn:collaboration>
+  <bpmn:process id="modell_parser_cyclic_timer_test" name="modell_parser_cyclic_timer_test" isExecutable="false">
+    <bpmn:laneSet>
+      <bpmn:lane id="Lane_1xzf0d3" name="Lane">
+        <bpmn:flowNodeRef>StartEvent_1mox3jl</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>EndEvent_0eie6q6</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>IntermediateThrowEvent_0tasnib</bpmn:flowNodeRef>
+      </bpmn:lane>
+    </bpmn:laneSet>
+    <bpmn:startEvent id="StartEvent_1mox3jl" name="Start Event">
+      <bpmn:outgoing>SequenceFlow_1e51499</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="EndEvent_0eie6q6" name="End Event">
+      <bpmn:incoming>SequenceFlow_0r6apa7</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1e51499" sourceRef="StartEvent_1mox3jl" targetRef="IntermediateThrowEvent_0tasnib" />
+    <bpmn:sequenceFlow id="SequenceFlow_0r6apa7" sourceRef="IntermediateThrowEvent_0tasnib" targetRef="EndEvent_0eie6q6" />
+    <bpmn:intermediateCatchEvent id="IntermediateThrowEvent_0tasnib" name="Cyclic Timer defintion">
+      <bpmn:incoming>SequenceFlow_1e51499</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0r6apa7</bpmn:outgoing>
+      <bpmn:timerEventDefinition>
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">Not Supported</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_1cidyxu">
+      <bpmndi:BPMNShape id="Participant_0px403d_di" bpmnElement="Participant_0px403d">
+        <dc:Bounds x="5" y="4" width="581" height="170" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_1xzf0d3_di" bpmnElement="Lane_1xzf0d3">
+        <dc:Bounds x="35" y="4" width="551" height="170" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_1mox3jl_di" bpmnElement="StartEvent_1mox3jl">
+        <dc:Bounds x="83" y="69" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_0eie6q6_di" bpmnElement="EndEvent_0eie6q6">
+        <dc:Bounds x="503" y="69" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1e51499_di" bpmnElement="SequenceFlow_1e51499">
+        <di:waypoint x="119" y="87" />
+        <di:waypoint x="268" y="87" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0r6apa7_di" bpmnElement="SequenceFlow_0r6apa7">
+        <di:waypoint x="304" y="87" />
+        <di:waypoint x="503" y="87" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="IntermediateCatchEvent_0s0hzl5_di" bpmnElement="IntermediateThrowEvent_0tasnib">
+        <dc:Bounds x="268" y="69" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="256" y="112" width="61" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/_integration_tests/bpmn/modell_parser_timer_invalid_date.bpmn
+++ b/_integration_tests/bpmn/modell_parser_timer_invalid_date.bpmn
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definition_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="BPMN Studio" exporterVersion="1">
+  <bpmn:collaboration id="Collaboration_1cidyxu" name="">
+    <bpmn:participant id="Participant_0px403d" name="modell_parser_timer_invalid_date" processRef="modell_parser_timer_invalid_date" />
+  </bpmn:collaboration>
+  <bpmn:process id="modell_parser_timer_invalid_date" name="modell_parser_timer_invalid_date" isExecutable="false">
+    <bpmn:laneSet>
+      <bpmn:lane id="Lane_1xzf0d3" name="Lane">
+        <bpmn:flowNodeRef>StartEvent_1mox3jl</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>EndEvent_0eie6q6</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>IntermediateThrowEvent_0fkriiu</bpmn:flowNodeRef>
+      </bpmn:lane>
+    </bpmn:laneSet>
+    <bpmn:startEvent id="StartEvent_1mox3jl" name="Start Event">
+      <bpmn:outgoing>SequenceFlow_0zcsuz7</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="EndEvent_0eie6q6" name="End Event">
+      <bpmn:incoming>SequenceFlow_0jode8r</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0zcsuz7" sourceRef="StartEvent_1mox3jl" targetRef="IntermediateThrowEvent_0fkriiu" />
+    <bpmn:sequenceFlow id="SequenceFlow_0jode8r" sourceRef="IntermediateThrowEvent_0fkriiu" targetRef="EndEvent_0eie6q6" />
+    <bpmn:intermediateCatchEvent id="IntermediateThrowEvent_0fkriiu" name="Timer with an invalid date definition">
+      <bpmn:incoming>SequenceFlow_0zcsuz7</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0jode8r</bpmn:outgoing>
+      <bpmn:timerEventDefinition>
+        <bpmn:timeDate xsi:type="bpmn:tFormalExpression">plz continue tomorrow</bpmn:timeDate>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_1cidyxu">
+      <bpmndi:BPMNShape id="Participant_0px403d_di" bpmnElement="Participant_0px403d">
+        <dc:Bounds x="5" y="4" width="581" height="170" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_1xzf0d3_di" bpmnElement="Lane_1xzf0d3">
+        <dc:Bounds x="35" y="4" width="551" height="170" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_1mox3jl_di" bpmnElement="StartEvent_1mox3jl">
+        <dc:Bounds x="83" y="69" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_0eie6q6_di" bpmnElement="EndEvent_0eie6q6">
+        <dc:Bounds x="503" y="69" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0zcsuz7_di" bpmnElement="SequenceFlow_0zcsuz7">
+        <di:waypoint x="119" y="87" />
+        <di:waypoint x="291" y="87" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0jode8r_di" bpmnElement="SequenceFlow_0jode8r">
+        <di:waypoint x="327" y="87" />
+        <di:waypoint x="503" y="87" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="IntermediateCatchEvent_0ryk4a6_di" bpmnElement="IntermediateThrowEvent_0fkriiu">
+        <dc:Bounds x="291" y="69" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="276" y="112" width="66" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/_integration_tests/bpmn/modell_parser_timer_invalid_duration.bpmn
+++ b/_integration_tests/bpmn/modell_parser_timer_invalid_duration.bpmn
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definition_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="BPMN Studio" exporterVersion="1">
+  <bpmn:collaboration id="Collaboration_1cidyxu" name="">
+    <bpmn:participant id="Participant_0px403d" name="modell_parser_timer_invalid_duration" processRef="modell_parser_timer_invalid_duration" />
+  </bpmn:collaboration>
+  <bpmn:process id="modell_parser_timer_invalid_duration" name="modell_parser_timer_invalid_duration" isExecutable="false">
+    <bpmn:laneSet>
+      <bpmn:lane id="Lane_1xzf0d3" name="Lane">
+        <bpmn:flowNodeRef>StartEvent_1mox3jl</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>EndEvent_0eie6q6</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>IntermediateThrowEvent_0blakxd</bpmn:flowNodeRef>
+      </bpmn:lane>
+    </bpmn:laneSet>
+    <bpmn:startEvent id="StartEvent_1mox3jl" name="Start Event">
+      <bpmn:outgoing>SequenceFlow_1k9fjeh</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="EndEvent_0eie6q6" name="End Event">
+      <bpmn:incoming>SequenceFlow_129mdq9</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1k9fjeh" sourceRef="StartEvent_1mox3jl" targetRef="IntermediateThrowEvent_0blakxd" />
+    <bpmn:sequenceFlow id="SequenceFlow_129mdq9" sourceRef="IntermediateThrowEvent_0blakxd" targetRef="EndEvent_0eie6q6" />
+    <bpmn:intermediateCatchEvent id="IntermediateThrowEvent_0blakxd" name="Invalid duration">
+      <bpmn:incoming>SequenceFlow_1k9fjeh</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_129mdq9</bpmn:outgoing>
+      <bpmn:timerEventDefinition>
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">plz wait here five seconds</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_1cidyxu">
+      <bpmndi:BPMNShape id="Participant_0px403d_di" bpmnElement="Participant_0px403d">
+        <dc:Bounds x="5" y="4" width="581" height="170" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_1xzf0d3_di" bpmnElement="Lane_1xzf0d3">
+        <dc:Bounds x="35" y="4" width="551" height="170" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_1mox3jl_di" bpmnElement="StartEvent_1mox3jl">
+        <dc:Bounds x="83" y="69" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_0eie6q6_di" bpmnElement="EndEvent_0eie6q6">
+        <dc:Bounds x="503" y="69" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1k9fjeh_di" bpmnElement="SequenceFlow_1k9fjeh">
+        <di:waypoint x="119" y="87" />
+        <di:waypoint x="271" y="87" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_129mdq9_di" bpmnElement="SequenceFlow_129mdq9">
+        <di:waypoint x="307" y="87" />
+        <di:waypoint x="503" y="87" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="IntermediateCatchEvent_0r936nt_di" bpmnElement="IntermediateThrowEvent_0blakxd">
+        <dc:Bounds x="271" y="69" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="252" y="112" width="75" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/_integration_tests/package.json
+++ b/_integration_tests/package.json
@@ -42,7 +42,7 @@
     "@process-engine/metrics_api_core": "~1.0.0",
     "@process-engine/metrics.repository.file_system": "~1.0.0",
     "@process-engine/process_engine_contracts": "~36.5.0",
-    "@process-engine/process_engine_core": "~8.7.0",
+    "@process-engine/process_engine_core": "feature~add_timer_validation",
     "@process-engine/process_model.repository.sequelize": "~4.2.0",
     "addict-ioc": "~2.5.1",
     "bluebird": "~3.5.3",

--- a/_integration_tests/test/parse_bpmn_model_to_object_model.js
+++ b/_integration_tests/test/parse_bpmn_model_to_object_model.js
@@ -129,7 +129,7 @@ describe('Process-Engine   Parse BPMN Process into new object model', () => {
     try {
       const result = await bpmnModelParser.parseXmlToObjectModel(cylicTimerBpmnFile);
 
-      should(result).be.undefined('The process definition should not be parsed.');
+      should.fail(result, undefined, 'The process definition should not have been parsed, because of a cyclic timer!');
     } catch (error) {
       should(error).have.property('code');
       should(error).have.property('message');
@@ -148,7 +148,7 @@ describe('Process-Engine   Parse BPMN Process into new object model', () => {
     try {
       const result = await bpmnModelParser.parseXmlToObjectModel(cylicTimerBpmnFile);
 
-      should(result).be.undefined('The process definition should not be parsed.');
+      should.fail(result, undefined, 'The process definition should not have been parsed, because the timer duration definition is invalid!');
     } catch (error) {
       should(error).have.property('code');
       should(error).have.property('message');
@@ -167,7 +167,7 @@ describe('Process-Engine   Parse BPMN Process into new object model', () => {
     try {
       const result = await bpmnModelParser.parseXmlToObjectModel(cylicTimerBpmnFile);
 
-      should(result).be.undefined('The process definition should not be parsed.');
+      should.fail(result, undefined, 'The process definition should not have been parsed, because the attached date timer definition is invalid!');
     } catch (error) {
       should(error).have.property('code');
       should(error).have.property('message');

--- a/_integration_tests/test/parse_bpmn_model_to_object_model.js
+++ b/_integration_tests/test/parse_bpmn_model_to_object_model.js
@@ -93,4 +93,50 @@ describe('Process-Engine   Parse BPMN Process into new object model', () => {
     should(process.sequenceFlows.length).be.equal(1);
   });
 
+  it('should sucessfully parse a ProcessModel which contains a valid timer definition', async () => {
+    const validTimerProcessName = 'intermediate_event_timer_test';
+
+    const validTimerBpmnFile = testFixtureProvider.readProcessModelFile(validTimerProcessName);
+
+    const result = await bpmnModelParser.parseXmlToObjectModel(validTimerBpmnFile);
+
+    // Basic Definitions-Properties
+    should.exist(result.xmlns);
+    should.exist(result.collaboration);
+    should(result.id).be.equal('Definitions_019scie');
+    should(result.processes).be.an.instanceOf(Array);
+    should(result.processes.length).be.equal(1);
+
+    // Collaboration and Participants
+    const collaboration = result.collaboration;
+
+    should(collaboration.id).be.equal('Definitions_019scie');
+    should(collaboration.participants).be.an.instanceOf(Array);
+    should(collaboration.participants.length).be.equal(1);
+
+    const participant = collaboration.participants[0];
+
+    should(participant.id).be.equal('Participant_1ndejx1');
+    should(participant.name).be.equal('intermediate_event_timer_test');
+    should(participant.processReference).be.equal('intermediate_event_timer_test');
+  });
+
+  it.only('should throw an UnprocessableEntity error when trying to parse a Process which contains a cyclic timer definition', async () => {
+    const cyclicTimerProcessName = 'modell_parser_cyclic_timer_test';
+
+    const cylicTimerBpmnFile = testFixtureProvider.readProcessModelFile(cyclicTimerProcessName);
+
+    try {
+      const result = await bpmnModelParser.parseXmlToObjectModel(cylicTimerBpmnFile);
+
+      should(result).be.undefined('The process definition should not be parsed.')
+    } catch (error) {
+      should(error).have.property('code');
+      should(error).have.property('message');
+      const errorCode = 422;
+      const errorMessage = /cyclic.*unsupported/i;
+      should(error.code).be.equal(errorCode);
+      should(error.message).be.match(errorMessage);
+    }
+  });
 });

--- a/_integration_tests/test/parse_bpmn_model_to_object_model.js
+++ b/_integration_tests/test/parse_bpmn_model_to_object_model.js
@@ -139,4 +139,23 @@ describe('Process-Engine   Parse BPMN Process into new object model', () => {
       should(error.message).be.match(errorMessage);
     }
   });
+
+  it('should throw an UnprocessableEntity error when trying to parse a Process which contains an invalid duration timer definition', async () => {
+    const cyclicTimerProcessName = 'modell_parser_timer_invalid_duration';
+
+    const cylicTimerBpmnFile = testFixtureProvider.readProcessModelFile(cyclicTimerProcessName);
+
+    try {
+      const result = await bpmnModelParser.parseXmlToObjectModel(cylicTimerBpmnFile);
+
+      should(result).be.undefined('The process definition should not be parsed.');
+    } catch (error) {
+      should(error).have.property('code');
+      should(error).have.property('message');
+      const errorCode = 422;
+      const errorMessage = /duration.*not.*format/i;
+      should(error.code).be.equal(errorCode);
+      should(error.message).be.match(errorMessage);
+    }
+  });
 });

--- a/_integration_tests/test/parse_bpmn_model_to_object_model.js
+++ b/_integration_tests/test/parse_bpmn_model_to_object_model.js
@@ -158,4 +158,24 @@ describe('Process-Engine   Parse BPMN Process into new object model', () => {
       should(error.message).be.match(errorMessage);
     }
   });
+
+  it('should throw an UnprocessableEntity error when trying to parse a Process which contains an invalid date timer definition', async () => {
+    const cyclicTimerProcessName = 'modell_parser_timer_invalid_date';
+
+    const cylicTimerBpmnFile = testFixtureProvider.readProcessModelFile(cyclicTimerProcessName);
+
+    try {
+      const result = await bpmnModelParser.parseXmlToObjectModel(cylicTimerBpmnFile);
+
+      should(result).be.undefined('The process definition should not be parsed.');
+    } catch (error) {
+      should(error).have.property('code');
+      should(error).have.property('message');
+      const errorCode = 422;
+      const errorMessage = /date.*not.*format/i;
+      should(error.code).be.equal(errorCode);
+      should(error.message).be.match(errorMessage);
+    }
+  });
+
 });

--- a/_integration_tests/test/parse_bpmn_model_to_object_model.js
+++ b/_integration_tests/test/parse_bpmn_model_to_object_model.js
@@ -131,8 +131,6 @@ describe('Process-Engine   Parse BPMN Process into new object model', () => {
 
       should.fail(result, undefined, 'The process definition should not have been parsed, because of a cyclic timer!');
     } catch (error) {
-      should(error).have.property('code');
-      should(error).have.property('message');
       const errorCode = 422;
       const errorMessage = /cyclic.*unsupported/i;
       should(error.message).be.match(errorMessage);
@@ -150,8 +148,6 @@ describe('Process-Engine   Parse BPMN Process into new object model', () => {
 
       should.fail(result, undefined, 'The process definition should not have been parsed, because the timer duration definition is invalid!');
     } catch (error) {
-      should(error).have.property('code');
-      should(error).have.property('message');
       const errorCode = 422;
       const errorMessage = /duration.*not.*format/i;
       should(error.message).be.match(errorMessage);
@@ -169,8 +165,6 @@ describe('Process-Engine   Parse BPMN Process into new object model', () => {
 
       should.fail(result, undefined, 'The process definition should not have been parsed, because the attached date timer definition is invalid!');
     } catch (error) {
-      should(error).have.property('code');
-      should(error).have.property('message');
       const errorCode = 422;
       const errorMessage = /date.*not.*format/i;
       should(error.message).be.match(errorMessage);

--- a/_integration_tests/test/parse_bpmn_model_to_object_model.js
+++ b/_integration_tests/test/parse_bpmn_model_to_object_model.js
@@ -121,7 +121,7 @@ describe('Process-Engine   Parse BPMN Process into new object model', () => {
     should(participant.processReference).be.equal('intermediate_event_timer_test');
   });
 
-  it.only('should throw an UnprocessableEntity error when trying to parse a Process which contains a cyclic timer definition', async () => {
+  it('should throw an UnprocessableEntity error when trying to parse a Process which contains a cyclic timer definition', async () => {
     const cyclicTimerProcessName = 'modell_parser_cyclic_timer_test';
 
     const cylicTimerBpmnFile = testFixtureProvider.readProcessModelFile(cyclicTimerProcessName);
@@ -129,7 +129,7 @@ describe('Process-Engine   Parse BPMN Process into new object model', () => {
     try {
       const result = await bpmnModelParser.parseXmlToObjectModel(cylicTimerBpmnFile);
 
-      should(result).be.undefined('The process definition should not be parsed.')
+      should(result).be.undefined('The process definition should not be parsed.');
     } catch (error) {
       should(error).have.property('code');
       should(error).have.property('message');

--- a/_integration_tests/test/parse_bpmn_model_to_object_model.js
+++ b/_integration_tests/test/parse_bpmn_model_to_object_model.js
@@ -135,8 +135,8 @@ describe('Process-Engine   Parse BPMN Process into new object model', () => {
       should(error).have.property('message');
       const errorCode = 422;
       const errorMessage = /cyclic.*unsupported/i;
-      should(error.code).be.equal(errorCode);
       should(error.message).be.match(errorMessage);
+      should(error.code).be.equal(errorCode);
     }
   });
 
@@ -154,8 +154,8 @@ describe('Process-Engine   Parse BPMN Process into new object model', () => {
       should(error).have.property('message');
       const errorCode = 422;
       const errorMessage = /duration.*not.*format/i;
-      should(error.code).be.equal(errorCode);
       should(error.message).be.match(errorMessage);
+      should(error.code).be.equal(errorCode);
     }
   });
 
@@ -173,9 +173,8 @@ describe('Process-Engine   Parse BPMN Process into new object model', () => {
       should(error).have.property('message');
       const errorCode = 422;
       const errorMessage = /date.*not.*format/i;
-      should(error.code).be.equal(errorCode);
       should(error.message).be.match(errorMessage);
+      should(error.code).be.equal(errorCode);
     }
   });
-
 });


### PR DESCRIPTION
**Changes:**

1. Adds an integration test which tests against the Timer Validations.

**Issues:**

Related https://github.com/process-engine/process_engine_runtime/issues/195

PR: #165

## How can others test the changes?

Run the tests.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [ ] I've tested **all** changes included in this PR.
- [ ] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [ ] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).