### PR TITLE
👷🐛 Fix Slack-Report generation after Jenkins builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,6 +26,7 @@ def cleanup_docker() {
   sh(script: "docker volume prune --force");
 }
 
+@NonCPS
 def slack_send_summary(testlog, test_failed) {
   def passing_regex = /\d+ passing/;
   def failing_regex = /\d+ failing/;
@@ -41,13 +42,13 @@ def slack_send_summary(testlog, test_failed) {
 
   def color_string     =  '"color":"good"';
   def markdown_string  =  '"mrkdwn_in":["text","title"]';
-  def title_string     =  "\"title\":\":white_check_mark: Process Engine Integration Tests for ${env.BRANCH_NAME} Succeeded!\"";
+  def title_string     =  "\"title\":\":white_check_mark: Process Engine Integration Tests for ${BRANCH_NAME} Succeeded!\"";
   def result_string    =  "\"text\":\"${passing}\\n${failing}\\n${pending}\"";
   def action_string    =  "\"actions\":[{\"name\":\"open_jenkins\",\"type\":\"button\",\"text\":\"Open this run\",\"url\":\"${RUN_DISPLAY_URL}\"}]";
 
   if (test_failed == true) {
     color_string = '"color":"danger"';
-    title_string =  "\"title\":\":boom: Process Engine Integration Tests for ${env.BRANCH_NAME} Failed!\"";
+    title_string =  "\"title\":\":boom: Process Engine Integration Tests for ${BRANCH_NAME} Failed!\"";
   }
 
   slackSend(attachments: "[{$color_string, $title_string, $markdown_string, $result_string, $action_string}]");


### PR DESCRIPTION
**Changes:**

Add `@NonCPS` decorator to `slack_send_summary` to fix the sending of the Slack-Report.
See this issue: https://stackoverflow.com/questions/40454558/jenkins-pipeline-java-io-notserializableexception-java-util-regex-matcher-error

PR: #173

## How can others test the changes?

- Run some Jenkins-Builds.
- A full test log should now be send to slack, in addition to the report.

![bildschirmfoto 2019-02-15 um 10 16 38](https://user-images.githubusercontent.com/15343316/52846793-cd946800-310a-11e9-9fcc-39c26e1e57e7.png)


## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).